### PR TITLE
Infer bean param type also from getters

### DIFF
--- a/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/DefaultParameterExtension.java
+++ b/modules/swagger-jaxrs/src/main/java/io/swagger/jaxrs/DefaultParameterExtension.java
@@ -133,6 +133,7 @@ public class DefaultParameterExtension extends AbstractSwaggerExtension {
             for (final BeanPropertyDefinition propDef : properties) {
                 final AnnotatedField field = propDef.getField();
                 final AnnotatedMethod setter = propDef.getSetter();
+                final AnnotatedMethod getter = propDef.getGetter();
                 final List<Annotation> paramAnnotations = new ArrayList<Annotation>();
                 final Iterator<SwaggerExtension> extensions = SwaggerExtensions.chain();
                 Type paramType = null;
@@ -156,6 +157,20 @@ public class DefaultParameterExtension extends AbstractSwaggerExtension {
                     }
 
                     for (final Annotation fieldAnnotation : setter.annotations()) {
+                        if (!paramAnnotations.contains(fieldAnnotation)) {
+                            paramAnnotations.add(fieldAnnotation);
+                        }
+                    }
+                }
+                
+                // Gather the getter's details but only the ones we need
+                if (getter != null) {
+                    // Do not set the param class/type from the getter if the values are already identified
+                    if (paramType == null) {
+                        paramType = getter.getGenericReturnType();
+                    }
+
+                    for (final Annotation fieldAnnotation : getter.annotations()) {
                         if (!paramAnnotations.contains(fieldAnnotation)) {
                             paramAnnotations.add(fieldAnnotation);
                         }


### PR DESCRIPTION
At the moment if you use frameworks like FreeBuilder (https://github.com/google/FreeBuilder) to create POJOs (with builders), you end up with interfaces or abstract classes that only have getters (with builders and concrete classes being automatically generated at compilation time).

Previously that would mean that those objects would be ignored by Swagger if used as @BeanParam on jersey resources; this change allows type params and annotations (like @QueryParam) to be picked up from getters.
